### PR TITLE
Removing pyspark library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 graphrag==0.2.2
-pyspark==3.5.1
 pyarrow==15.0.0
 pandas==2.2.2
 ipykernel==6.29.5


### PR DESCRIPTION
Removing "pyspark" library to speed-up the container build process.